### PR TITLE
Fixed a bug in the ZYZ decomposition

### DIFF
--- a/src/qdecomp/decompositions/zyz.py
+++ b/src/qdecomp/decompositions/zyz.py
@@ -115,9 +115,9 @@ def zyz_decomposition(U: NDArray) -> tuple[float, ...]:
     b = 2 * np.atan2(V10_.imag, V10_.real)
 
     # The following system of equations is solved to find t0 and t2
-    # t0 + t2 = a
-    # t0 - t2 = b
-    t0 = (a + b) / 2
-    t2 = (a - b) / 2
+    # t0 - t2 = a
+    # t0 + t2 = b
+    t0 = (a - b) / 2
+    t2 = (a + b) / 2
 
     return t0, t1, t2, alpha

--- a/tests/test_decompositions/test_zyz.py
+++ b/tests/test_decompositions/test_zyz.py
@@ -14,8 +14,8 @@
 
 import numpy as np
 import pytest
-
 from qdecomp.decompositions import zyz_decomposition
+from scipy.stats import unitary_group
 
 
 # Rotation and phase matrices
@@ -59,6 +59,21 @@ def test_zyz_decomposition(a, b, alpha):
     U_calculated = phase(alpha_) * rz(t2) @ ry(t1) @ rz(t0)
 
     assert np.allclose(U, U_calculated, atol=1e-7, rtol=1e-7)
+
+
+def test_zyz_decomposition_arbitrary_unitary():
+    """
+    Test the ZYZ decomposition of arbitrary unitary matrices.
+    """
+    unitary_generator = unitary_group(dim=2, seed=42)
+    for _ in range(15):
+        U = unitary_generator.rvs()  # Generate a random unitary matrix
+        t0, t1, t2, alpha_ = zyz_decomposition(U)
+
+        # Check that the decomposition is correct
+        U_calculated = phase(alpha_) * rz(t2) @ ry(t1) @ rz(t0)
+
+        assert np.allclose(U, U_calculated, atol=1e-7, rtol=1e-7)
 
 
 def test_zyz_decomposition_unitary_error():


### PR DESCRIPTION
Fixed a bug in the ZYZ decomposition.

Here was the problem (the assertion failed):
```
U = random_unitary()  # Generate a random unitary
t0, t1, t2, alpha_ = zyz_decomposition(U)  # Find its decomposition

U_calculated = phase(alpha_) * rz(t2) @ ry(t1) @ rz(t0)  # Recalculate U from the angles of its decomposition

assert np.allclose(U, U_calculated, atol=1e-7, rtol=1e-7)  # Assert the recombination is the same as the initial unitiary
```

The problem was that t0 and t2 were reversed in the function that computes the decomposition.